### PR TITLE
Massive changes to the stal/IX website

### DIFF
--- a/ACCEL.md
+++ b/ACCEL.md
@@ -1,22 +1,22 @@
-# Accel
+# 3D acceleration
 
-> Prereq:<br>
+> Prerequisites:<br>
 > [FS.md](FS.md)<br>
 > [IX.md](IX.md)
 
 <!-- {% raw %} -->
 
-**stal/IX** is a statically linked Linux distribution, so the 3D drivers are also compiled statically.
+**stal/IX** is a statically linked Linux distribution, so 3D drivers are also compiled statically.
 
 The driver that the application is built with depends on the mesa_driver variable.
 
-It can be installed on realm:
+It can be installed in the realm:
 
 ```shell
 user# ix mut --mesa_driver=radeonsi
 ```
 
-Then all applications built in this realm via ix mut/ix let will use the selected driver.
+Then all applications built in this realm using `ix mut`/`ix let` will use the selected driver.
 
 Or for a standalone application:
 
@@ -40,22 +40,22 @@ lib/mesa/drivers/valve
 lib/mesa/drivers/vulkan
 ```
 
-Rule of thumb - if the name is the name of the vulkan driver from mesa, then Zink will be selected as the opengl driver - https://docs.mesa3d.org/drivers/zink.html.
+Rule of thumb - if the name matches the name of the Vulkan driver from Mesa, then Zink will be chosen as the OpenGL driver - [https://docs.mesa3d.org/drivers/zink.html](https://docs.mesa3d.org/drivers/zink.html).
 
-So to use zink + vulkan amd radv driver run:
+So, to use the Zink + Vulkan AMD RADV driver, run:
 
 ```shell
 user# ix mut --mesa_driver=radv
 ```
 
-If zink + vulkan bunch works for you, then it is preferable, because the ACO shader compiler is significantly smaller in size than the LLVM option.
+If zink + vulkan is a good choice for you, it is preferable because the ACO shader compiler is significantly smaller in size than the LLVM variant.
 
-## Quirks:
-* If you want to use zink + vulkan, it is recommended to add to your session script: 
+## Oddities
+* If you want to use Zink + Vulkan, it is recommended to add to your session script: 
 ```shell
 export WLR_RENDERER=vulkan # for wlroots-based composers
 export MESA_LOADER_DRIVER_OVERRIDE=zink
 ```
-* Intel cards operates with mesa_driver=iris, but fails with mesa_driver=anv.
+* Intel cards work with mesa_driver=iris, but do not work with mesa_driver=anv.
 
 <!-- {% endraw %} -->

--- a/CASES.md
+++ b/CASES.md
@@ -4,9 +4,9 @@
 
 <!-- {% raw %} -->
 
-**IX** renders obsolete many different ways to compile statically linked binaries:
+**IX** obsoletes many ways of compiling statically linked binaries:
 
-[buildroot](https://buildroot.org/)
+[Buildroot](https://buildroot.org/)
 
 ```shell
 ix# ix build --target=linux-aarch64 --for_target=linux-riscv64 bin/gcc bin/binutils
@@ -18,22 +18,22 @@ ix# ix build --target=linux-aarch64 --for_target=linux-riscv64 bin/gcc bin/binut
 ix# ix build --target=linux-aarch64 bin/clang/16
 ```
 
-[busybox](https://www.busybox.net/downloads/binaries/)
+[BusyBox](https://www.busybox.net/downloads/binaries/)
 
 ```shell
 ix# ix build --target=linux-aarch64 --purec=musl/pure bin/busybox/ix
 ix# ix build --target=linux-aarch64 --purec=uclibc/ng bin/busybox/ix
 ```
 
-[static tmux](https://github.com/mjakob-gh/build-static-tmux)<br>
-[another static tmux](https://github.com/maciejjo/static-tmux)<br>
-[and how to build one!](https://stackoverflow.com/questions/62620514/building-static-executable-tmux-on-linux)
+[Static tmux](https://github.com/mjakob-gh/build-static-tmux)<br>
+[Another static tmux](https://github.com/maciejjo/static-tmux)<br>
+[and how to build it!](https://stackoverflow.com/questions/62620514/building-static-executable-tmux-on-linux)
 
 ```shell
 ix# ix build bin/tmux
 ```
 
-[how to build static git](https://stackoverflow.com/questions/11570188/how-to-build-git-with-static-linking)<br>
+[How to build static Git](https://stackoverflow.com/questions/11570188/how-to-build-git-with-static-linking)<br>
 [again](https://github.com/EXALAB/git-static)<br>
 [and again...](https://gist.github.com/mishudark/3080857)
 

--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -1,40 +1,40 @@
 # Caveats
 
-> This document contains a regularly replenishing list of warnings and cautions. Pay attention, don't miss it out.
+> This document contains a regularly updated list of warnings and cautions. Please pay attention and do not miss them.
 
 <!-- {% raw %} -->
 
-**Main alsa channel** after boot can be muted, adjust volume with alsamixer, and don't forget to unmute channel (with M).
+The **main ALSA channel** can be muted after booting, adjust the volume with alsamixer and don't forget to unmute the channel (using M).
 
-**Volume settings** don't survive reboot. Add to your session script (e.g. .profile):
+**Volume settings** are not saved after reboot. Add to your session script (e.g. .profile):
 
 ```shell
 amixer sset Master unmute
 amixer sset Master 100%
 ```
 
-**Logs** doesn't survive reboot.
+**Logs** are not saved after reboot.
 
-**iwctl passwords** doesn't survive reboot.
+**iwctl passwords** are not saved after reboot.
 
-**Any global state**, actually, don't survive reboot, system completely stateless by now, need to investigate proper solution for this.
+In fact, **any global state** is not saved after reboot, the system is now completely stateless. A suitable solution must be found for this problem.
 
-**No logrotate for logs** in /var/run/, but, they also don't survive reboot, so, this is not a real problem for now.
+There is **no logrotate for logs** in /var/run/, but they are also not saved after reboot, so that's not a real issue at the moment.
 
-**/ix/build folder trashed every 1000 seconds** [https://github.com/stal-ix/ix/blob/main/pkgs/bin/sched/builddir/ix.sh#L11](https://github.com/stal-ix/ix/blob/main/pkgs/bin/sched/builddir/ix.sh#L11), so, to debug build problems, do one of the following:  
-* copy build dir somewhere else;
-* or, disable this scheduler altogeter.
+The **/ix/build folder is cleaned every 1000 seconds** ([https://github.com/stal-ix/ix/blob/main/pkgs/bin/sched/builddir/ix.sh#L11](https://github.com/stal-ix/ix/blob/main/pkgs/bin/sched/builddir/ix.sh#L11)), so to troubleshoot build issues, do one of the following:
+* copy the build directory to another location;
+* or, disable this scheduler altogether.
 
-**ACPI** rules very approximate, actually, activated only on lid close/open.
+The **ACPI** rules are very rough, in fact they are only activated when the lid is closed/opened.
 
-**Power management** is very basic . For now, we're running CPU at full speed, because linux governors are a mess.
+**Power management** is very basic. For now, we're running the CPU at full speed, because Linux governors are a mess.
 
-**/etc/services**, despite being part of read-only realm, are currently writeable for runit.
+**/etc/services**, despite being part of a read-only realm, is currently writable by the init.
 
-**/dev/protection** is weak - [https://github.com/stal-ix/ix/blob/main/pkgs/bin/mdevd/runit/scripts/bad.conf](https://github.com/stal-ix/ix/blob/main/pkgs/bin/mdevd/runit/scripts/bad.conf).
+**/dev protection** is weak - [https://github.com/stal-ix/ix/blob/main/pkgs/bin/mdevd/runit/conf/bad.conf](https://github.com/stal-ix/ix/blob/main/pkgs/bin/mdevd/runit/conf/bad.conf).
 
-**IX runtime** are not safe enough - execution nodes have full access to /, and network isolation currently not really enforced.
+The **IX runtime** is not secure enough - runtime nodes have full access to /, and network isolation is not currently properly enforced.
 
-**Service supervisor** is more like a stub than a real program - [https://github.com/stal-ix/ix/blob/main/pkgs/bin/runsrv/srv](https://github.com/stal-ix/ix/blob/main/pkgs/bin/runsrv/srv).
+The **service supervisor** is more like a stub than a real program - [https://github.com/stal-ix/ix/blob/main/pkgs/bin/runsrv/scripts/srv](https://github.com/stal-ix/ix/blob/main/pkgs/bin/runsrv/scripts/srv).
 
 <!-- {% endraw %} -->

--- a/ETC.md
+++ b/ETC.md
@@ -1,6 +1,6 @@
 # etc
 
-> Prereq:<br>
+> Prerequisites:<br>
 > [FS.md](FS.md)<br>
 > [IX.md](IX.md)
 
@@ -13,11 +13,11 @@ ix# ls -la /etc
 lrwxrwxrwx ... /etc -> /ix/realm/system/etc
 ```
 
-Files in the IX store are read only, they can't be changed. Therefore, the only way to make a setting in the installed OS **stal/IX**, is to add some package that contains the needed setting to the system realm.<br>
+Files in the IX store are read-only and cannot be modified. Therefore, the only way to make a customization in an installed **stal/IX** OS is to add a package containing the desired customization to the system realm.<br>
 
-Most of these packages are etc/ prefixed and are located in [https://github.com/stal-ix/ix/tree/main/pkgs/etc](https://github.com/stal-ix/ix/tree/main/pkgs/etc)
+Most of these packages have the etc/ prefix and are located at [https://github.com/stal-ix/ix/tree/main/pkgs/etc](https://github.com/stal-ix/ix/tree/main/pkgs/etc).
 
-*Warning:* It's important to note that, after almost any change to the system realm, runit will restart the entire process tree. Effectively, this will result in you being kicked into your login manager (emptty/mingetty/etc).
+*Warning:* It's important to note that, after almost any change to the system realm, the init will restart the entire process tree. Effectively, this will result in you being kicked into your login manager (emptty/mingetty/etc).
 
 ## Add user
 
@@ -52,7 +52,7 @@ root# ix mut system etc/user/0 --pubkey="$(cat /home/{{username}}/.ssh/id_rsa.pu
 ix# ix mut system etc/zram/0
 ```
 
-## Remove the root console from tty5 that we added during installation
+## Remove root console from tty5 which we added during installation
 
 ```shell
 ix# ix mut system --failsafe=-
@@ -60,22 +60,22 @@ ix# ix mut system --failsafe=-
 
 ## Replace mingetty with emptty as login manager
 
-*ProTip:* First try looking at [https://github.com/stal-ix/ix/blob/main/pkgs/set/system/0/unwrap/ix.sh#L18](https://github.com/stal-ix/ix/blob/main/pkgs/set/system/0/unwrap/ix.sh#L18), and come up with what the next command might look like!
+*Pro tip:* First try looking at [https://github.com/stal-ix/ix/blob/main/pkgs/set/stalix/unwrap/ix.sh#L32](https://github.com/stal-ix/ix/blob/main/pkgs/set/stalix/unwrap/ix.sh#L32) and imagine what the next command might look like!
 
-*Warning:* if you don't have ~/.emptty configured, and don't have a failsafe console on tty5, then you may need a recovery.
+*Warning:* If you don't have ~/.emptty set up and don't have a failsafe console on tty5, you may need to recover.
 
 ```shell
 ix# ix mut system --mingetty=- --emptty
 ```
 
-## Timezone settings
-The system uses UTC time by default. There is currently no global timezone setting, each user must set their own timezone in their session script:
+## Time zone settings
+The system uses UTC time by default. There is currently no global time zone setting, each user must set their own time zone in their session script:
 
 ```shell
 export TZ=Europe/Moscow
 ```
 
-## Change sndio's alsa device
+## Change ALSA device in sndio
 
 ```shell
 ix# ix mut system --alsa_device=hw:1

--- a/FS.md
+++ b/FS.md
@@ -1,12 +1,12 @@
 # stal/IX Filesystem
 
 
-> This document describes the **stal/IX** file system layout.
+> This document describes the structure of the **stal/IX** filesystem.
 
 <!-- {% raw %} -->
 
-The /ix/store/ contains a folders set, each package corresponds to one folder.<br>
-Folders form a content addressable store, that is, all paths uniquely identify a unique package.
+/ix/store/ contains a set of folders, each package corresponding to one folder.<br>
+The folders form a content-addressable store, i.e. all paths uniquely identify a unique package.
 
 ```shell
 pg-> ls -la /ix/store/ | head -n 10
@@ -35,13 +35,13 @@ lrwxrwxrwx    1 pg       10000           33 Dec 11 16:46 pg -> /ix/store/w5qTNK0
 lrwxrwxrwx    1 pg       10000           37 Dec 11 06:08 system -> /ix/store/oQfJCY3xa3jlPkNf-rlm-system
 ```
 
-Actually, these are "roots" by which the **IX** package manager can understand what is actively used in /ix/store/ and what can be safely removed using the `ix gc` command.
+In fact, these are the "roots" that the **IX** package manager can use to figure out what is actively used in /ix/store/ and what can be safely removed using the `ix gc` command.
 
 Some realms are predefined:
 
-/ix/realm/system - the "system" realm, it contains code needed to boot the OS.
+/ix/realm/system - the "system" realm, contains the code necessary to boot the OS.
 
-Root folders /etc, /bin look at the system realm:
+The root folders /etc, /bin look at the system realm:
 
 ```shell
 pg-> ls -la /bin /etc
@@ -49,18 +49,18 @@ lrwxrwxrwx    1 root     root            20 May 22  2022 /bin -> /ix/realm/syste
 lrwxrwxrwx    1 root     root            20 May 22  2022 /etc -> /ix/realm/system/etc
 ```
 
-By the way, this is why there's no point in editing files in /etc, they'll be updated with any update of /ix/realm/system.
+By the way, this is why there is no point in editing files in /etc, they will be updated with any update of /ix/realm/system.
 
-For every user in the system with name USER, there is a realm /ix/realm/USER, that belongs to that user:
+For each user on the system named USER, there is a realm /ix/realm/USER that belongs to that user:
 
-* it's default when using ix mut: `ix mut bin/nano` will install nano in your personal realm.
-* it comes first in PATH:
+* It is the default when using `ix mut`: `ix mut bin/nano` will install nano in your personal realm.
+* It comes first in PATH:
 
 ```shell
 pg-> echo ${PATH}
 /ix/realm/pg/bin:/bin
 ```
 
-To make it work, your session manager must do `. /etc/session`
+For this to work, your session manager must do `. /etc/session`.
 
 <!-- {% endraw %} -->

--- a/GRUB.md
+++ b/GRUB.md
@@ -2,16 +2,18 @@
 
 This text assumes that you know what GRUB is, what it is used for, and have a general understanding of how a computer boots up.
 
-(1) https://wiki.archlinux.org/title/GRUB<br>
-(2) https://wiki.archlinux.org/title/EFI_system_partition<br>
-(3) https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface<br>
+(1) [https://wiki.archlinux.org/title/GRUB](https://wiki.archlinux.org/title/GRUB)<br>
+(2) [https://wiki.archlinux.org/title/EFI_system_partition](https://wiki.archlinux.org/title/EFI_system_partition)<br>
+(3) [https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface](https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface)<br>
 
-Become root:
+Become root user:
 ```
 $ sudo sh
 ```
 
-Mount the pseudo FS with EFI variables: 
+Mount the pseudo filesystem with EFI variables:
+
+
 ```
 # mount -t efivarfs efivarfs /sys/firmware/efi/efivars
 ```
@@ -24,7 +26,7 @@ Mount the EFI partition (if it does not exist, the process of creating it is wel
 # mount {{your_efi_partition}} /esp
 ```
 
-Install necessary tools:
+Install the necessary tools:
 ```
 # ix mut set/boot/efi
 ```

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,6 +1,6 @@
 # stal/IX Documentation Style Guide
 
-> This guide defines the temporary standard for the **stal/IX** documentation formatting on GitHub.
+> This guide defines a temporary formatting standard for **stal/IX** documentation on GitHub.
 
 <!-- {% raw %} -->
 
@@ -10,53 +10,53 @@
 
 Used in all documents:
 
-**Headings** - created with one to six `#` (depending on size required) before heading text. `# The title of the document` (h1) is written in the first line.
+**Headings** - are created by using one to six `#` symbols (depending on the required size) before the heading text. `# The document title` (h1) is written on the first line.
 
-**Paragraphs and line breaks** - leave a blank line between text lines for paragraphs, use `<br>` at the end of the previous line for line breaks.
+**Paragraphs and line breaks** - Leave a blank line between lines of text for paragraphs, use `<br>` at the end of the previous line for line breaks.
 
-**Styling text** - italic - by `*asterisks*`; bold - double `**asterisks**`; combined emphasis - `**asterisks and _underscores_**`.
+**Text formatting** - italics - `*asterisks*`; bold - double `**asterisks**`; combined highlighting - `**asterisks and _underscores_**`.
 
-**Quotes** - created with `>` before quoting text. Here is used for Prereq block markup. If there is no Prereq - quote  the document description.<br> 
-Exception: if there are `> indeed quotes`, markup Prereq as a bulleted list, the document description - as a plain text in the first paragraph.
+**Quotes** - created with `>` before quoting text. Used here to mark up a Prerequisites block. If there is no Prerequisites, quote the document description.<br> 
+Exception: if there are `> indeed quotes`, mark up Prerequisites as a bulleted list, and the document description as plain text in the first paragraph.
 
-**Code and syntax highlighting** - framed by single backticks for inline `code` - \`code\`; fenced by lines with triple backticks - \`\`\` for  code blocks.<br>
-Use language prefix next to the top triple backticks line for code highlighting, without whitespace - \`\`\`shell.<br>
+**Code and syntax highlighting** - enclosed in single backticks for inline `code` - \`code\`; enclosed in triple backticks - \`\`\` for  code blocks.<br>
+Use a language prefix next to the top line of triple backticks for code highlighting, no spaces - \`\`\`shell.<br>
 
 Also used:
 
-**Lists**: ordinary - each item on a new line, use `<br>` (for example, to list links); bulleted - use asterisks `* some text`.
+**Lists**: regular - each item on a new line, use `<br>` (e.g. to list links); bulleted - use asterisks `* some text`.
 
-**Links**: URLs will automatically get turned into links, or you can create an inline link by wrapping link text in brackets.<br>
-`https://github.com/stal-ix/ix or [stal/IX](https://github.com/stal-ix/ix)` [https://github.com/stal-ix/ix](https://github.com/stal-ix/ix) or [stal/IX](https://github.com/stal-ix/ix)
+**Links**: You can create an inline link by enclosing the link text in brackets.<br>
+`[stal/IX](https://github.com/stal-ix/ix)` [stal/IX](https://github.com/stal-ix/ix)
 
-**Horizontal separation-line** - created by three (or more) hyphens `---`. Use it to highlight special text blocks, for example: *Exercise*. In the document’s body the block is highlighted with two separation-lines, above and below, if the block at the end of the document - with one separation-line above.
+**Horizontal dividing line** - formed by three (or more) hyphens `---`. Use it to highlight special text blocks, for example: *Exercise*. In the text of a document, a block is highlighted by two dividing lines, at the top and bottom, if the block is at the end of the document - by one dividing line at the top.
 
 ---
 
 ## stal/IX documentation
 
-The documentation is under development, it is updated and supplemented regularly.
+The documentation is under development and is regularly updated.
 
-All **stal/IX** documentation is formatted using [Markdown](https://en.wikipedia.org/wiki/Markdown). [HTML](https://en.wikipedia.org/wiki/HTML) is permitted if there is no Markdown equivalent or special formatting is required.
+All **stal/IX** documentation is formatted using [Markdown](https://en.wikipedia.org/wiki/Markdown). [HTML](https://en.wikipedia.org/wiki/HTML) is acceptable if there is no Markdown equivalent or special formatting is required.
 
-**stal/IX** is written as is, with a lowercase letter, even in the title or in the beginning of a sentence, **IX** is written in capital letters, if **IX** package manager is meant. **stal/IX** is highlighted in bold.
+**stal/IX** is written as is, with a lowercase letter, even in a title or at the beginning of a sentence, **IX** is written in capital letters if **IX** package manager is meant. **stal/IX** is written in bold.
 
-## Overall documentation markup
+## General documentation markup
 
-A document always starts with its title. Title is located at the top, the first line. No buttons, shields, banners, quotes or other design and formatting elements are placed above it.
+A document always begins with a title. The title is placed at the top, on the first line. There are no buttons, shields, banners, quotes or other design or formatting elements above it.
 
-To place below the title:
+Place under the title:
 
-* Shields, buttons and other elements if needed;
-* Prereq;
+* Shields, buttons and other elements if necessary;
+* Prerequisites;
 * Document description. 
 
-Document sections are marked with [headings](GUIDE.md#headings).<br>
+The sections of the document are designated by [headings](GUIDE.md#headings).<br>
 Special text blocks - with [horizontal rule](GUIDE.md#horizontal-rule).
 
 ## Headings
 
-Heading created with one to six `#` symbols (depending on size required) before heading text.
+Headings are created by using one to six `#` symbols (depending on required size) before the heading text.
 
 ```Markdown
 # h1 - the largest heading
@@ -74,21 +74,21 @@ Heading created with one to six `#` symbols (depending on size required) before 
 ##### h5
 ###### h6 - the smallest heading
 
-Heading `# h1` markups the document title in the first line. There can only be one h1 heading in a document.<br>
-The second-level heading `# h2` highlights document sections, if any. Next, if necessary, use the other heading levels.
+The `# h1` heading marks the document title on the first line. There can only be one h1 heading per document.<br>
+The second-level `# h2` heading marks the document sections, if any. Then, use the other heading levels as needed.
 
 ## Paragraphs and line breaks
 
-Paragraph -  leave a blank line between text lines. Line breaks - use `<br>` at the end of the previous line.
+Paragraph - leave a blank line between lines of text. Line breaks - use `<br>` at the end of the previous line.
 
-*Important!* Markdown Here rules for line breaks (two whitespaces at the end of a line) are not used to avoid removing trailing whitespaces with appropriate editor settings.
+*Important:* Markdown Here's line break rules (two spaces at the end of a line) are not used to avoid removing trailing spaces when the editor is set to do so.
 
 ## Text styling
 
-Used bold and italic:<br> 
+Bold and italic are used:<br> 
 * italic - `*asterisks*`; 
 * bold type - double `**asterisks**`; 
-* combined emphasis - `**asterisks and _underscores_**`.
+* combined highlighting - `**asterisks and _underscores_**`.
 
 Required text highlightings:<br>
 * *Pro tip* - `*Pro tip*` italic
@@ -97,23 +97,23 @@ Required text highlightings:<br>
 
 ## Quoting text
 
-Use the `>` symbol before quoting text. 
+Before quoting text, use the `>` symbol. 
 
 ```Markdown
 > Quoting text
 ```
 > Quoting text
 
-Here we markup the Prereq block as a quote. If there are no prerequisites in the document, quote the document description.<br>
-Exception: if there are indeed quotes in the upper part of the document’s text (the first two paragraphs), then markup the Prereq with a bulleted list, the document description as a plain text in the first paragraph.
+Here we mark the Prerequisites block as a quote. If the document has no prerequisites, quote the document description.<br>
+Exception: if the top of the document text (the first two paragraphs) indeed has quotes, then mark the Prerequisites as a bulleted list, the document description as plain text in the first paragraph.
 
 ## Code quoting and syntax highlighting
 
-To inline `code` or `command output` within a sentence, use single backticks - \`code\` or \`command output\`.
-To format code or scripts into distinct block, use triple backticks.<br>
-Use the language prefix next to the top triple backticks line, without whitespace, for code highlighting - \`\`\`shell.
+To embed `code` or `command output` in a sentence, use single backticks - \`code\` or \`command output\`.
+To format code or scripts in a separate block, use triple backticks.<br>
+Use a language prefix next to the top line of triple backticks, with no spaces, to highlight code - \`\`\`shell.
 
-\`\`\`shell
+\`\`\`Markdown
 
 code block
 
@@ -127,8 +127,9 @@ code block
 
 **Unordered lists:**
 
-* ordinary - each item on a new line, use line breaks `<br>` (for example, to list links);
-* bulleted - markup with asterisks through a whitespace.<br>
+* regular - each item on a new line, use line breaks `<br>` (for example, to list links);
+* bulleted - markup with asterisks separated by spaces.<br>
+<!-- Does not render properly -->
 ```Markdown
 * point a; 
 * point b.
@@ -136,23 +137,23 @@ code block
 
 **Ordered (numbered) lists:**
 
-Due to the fact that the documentation is under development and is regularly supplemented, we do not use numbered lists yet.
+Due to the fact that the documentation is still under development and is regularly updated, we do not use numbered lists yet.
 
 ## Links
 
 ### Absolute links
 
-URLs will automatically get turned into links, or you can create an inline link by wrapping the link text in brackets `[ ]`, and the URL in parentheses `( )`, without a whitespace.
+You can create an inline link by enclosing the link text in square brackets `[ ]` and the URL in parentheses `( )`, without spaces.
 
 ```Markdown
-https://github.com/stal-ix/ix or [IX package manager](https://github.com/stal-ix/ix)
+[IX package manager](https://github.com/stal-ix/ix)
 ```
 
-[https://github.com/stal-ix/ix](https://github.com/stal-ix/ix) or [IX package manager](https://github.com/stal-ix/ix)
+[IX package manager](https://github.com/stal-ix/ix)
 
 ### Relative links
 
-The link text is wrapped in brackets, the link itself - in parentheses, without a whitespace.
+The link text is enclosed in square brackets, the link itself is enclosed in parentheses, without spaces.
 
 ```Markdown
 [STALIX.md](STALIX.md)
@@ -160,11 +161,11 @@ The link text is wrapped in brackets, the link itself - in parentheses, without 
 
 [STALIX.md](STALIX.md)
 
-A relative link is a link that is relative to the current file. Define relative links to navigate to other files in the same repository, since absolute links may not work in repository clones.
+A relative link is a link that is relative to the current file. Define relative links to navigate to other files in the same repository, as absolute links may not work in clones of a repository.
 
 ## Horizontal rule
 
-To create a horizontal separation-line use three (or more) hyphens `---`. Horizontal rule is used to highlight special text blocks (for example, Exercise).
+To create a horizontal dividing line, use three (or more) hyphens `---`. The horizontal line is used to separate special blocks of text (e.g. Exercise).
 
 ```Markdown
 ---
@@ -180,10 +181,10 @@ special text block
 
 ---
 
-In the document’s body the block is highlighted with two separation-lines, above and below, if the block at the end of the document (for example, comments) - with one separation-line above. A blank line between the last text’s line of the block and the bottom separation-line is needed.  
+In the text of the document, the block is separated by two dividing lines, at the top and bottom, if the block is at the end of the document (for example, comments) - by one dividing line at the top. There must be a blank line between the last line of the block text and the bottom dividing line.
 
 ## Ignoring Markdown formatting
 
-To ignore Markdown formatting, use `\` before a Markdown symbol.
+To ignore Markdown formatting, use `\` before a Markdown character.
 
 <!-- {% endraw %} -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,13 +1,16 @@
 # Installation
 <sup> The stal/IX on-disk installation guide </sup>
 
-> Prereq:<br>
+> Prerequisites:<br>
 > [IX.md](IX.md)<br>
 > [FS.md](FS.md)<br>
 
+**_Disclaimer:_**<br>
+*It is recommended that you have at least 100 GB of free storage space to bootstrap stal/IX. Expect this process to take 15 hours or more on some older and/or less powerful hardware, so be patient.*
+
 <!-- {% raw %} -->
 
-Load the machine from a bootable media, such as Ubuntu/Fedora/Nix livecd, and launch the terminal:
+Boot the machine from a bootable media, such as an Ubuntu/Fedora/NixOS live CD, and launch a terminal:
 
 ```shell
 sudo sh
@@ -17,13 +20,13 @@ Install the tools:
 
 ```shell
 test -f /usr/bin/parted || yum install parted || apt-get install parted
-# gcc >= 13 can not boostrap IX right now, so we prefer clang where available
+# gcc >= 13 can't bootstrap IX right now, so we prefer Clang where possible	
 test -f /usr/bin/g++ || yum install clang lld || yum install g++ || apt-get install g++
 test -f /usr/bin/git || yum install git || apt-get install git
 ```
 
-For general instructions on disk partitioning, refer to<br>
-https://wiki.archlinux.org/title/installation_guide#Partition_the_disks.<br>
+For general instructions on partitioning a disk, see<br>
+[https://wiki.archlinux.org/title/installation_guide#Partition_the_disks](https://wiki.archlinux.org/title/Installation_guide#Partition_the_disks).<br>
 
 Prepare EXT4 on /dev/xxx using parted, mkfs.ext4, and mount it:
 
@@ -32,7 +35,7 @@ mkdir /mnt/ix
 mount /dev/xxx /mnt/ix
 ```
 
-Prepare some symlinks to form the future rootfs:
+Prepare several symbolic links to form the future root filesystem:
 
 ```shell
 cd /mnt/ix
@@ -44,47 +47,47 @@ ln -s / usr
 mkdir -p home/root var sys proc dev
 ```
 
-Add a symlink to trick **IX** package manager:
+Add a symbolic link to trick the **IX** package manager:
 
 ```shell
 ln -s /mnt/ix/ix /ix
 ```
 
-Add a user "**ix**" who will own all packages in the system (note: UID 1000 is important):
+Add user "**ix**" who will own all packages on the system (note: UID 1000 is important):
 
 ```shell
 useradd -ou 1000 ix
 ```
 
-Prepare a managed dir owned by user **ix**, in /ix, /ix/realm, etc:
+Prepare a managed directory owned by user **ix** in /ix, /ix/realm, etc.:
 
 ```shell
 mkdir ix
 chown ix ix
 ```
 
-Prepare the **ix** user home owned by **ix**:
+Prepare the home directory of user **ix**, owned by **ix**:
 
 ```shell
 mkdir home/ix
 chown ix home/ix
 ```
 
-Change the user to **ix** and run all commands under **ix** user:
+Change user to **ix** and run all commands as user **ix**:
 
 ```shell
 su ix
 cd /mnt/ix
 ```
 
-Fetch **IX** package manager, will be used later, from ix user before reboot and by root user after reboot:
+Download the **IX** package manager, which will be used later, as the ix user before rebooting and as the root user after rebooting:
 
 ```shell
-# we do not want to change our CWD
+# we don't want to change our CWD
 (cd home/ix; git clone https://github.com/stal-ix/ix.git)
 ```
 
-Some quirks:
+Some oddities:
 
 ```shell
 # like tmp dir, so realm symlink can be modified only by its creator/owner
@@ -93,7 +96,7 @@ Some quirks:
 mkdir -m 01777 ix/realm
 ```
 
-And run **IX** package manager to populate the root fs with bootstrap tools:
+And run the **IX** package manager to populate the root filesystem with bootstrap tools:
 
 ```shell
 cd home/ix/ix
@@ -104,21 +107,21 @@ export IX_EXEC_KIND=local
 ./ix mut boot set/boot/all
 ```
 
-Now [prepare a bootable kernel for your hardware](KERNEL.md). Reboot into grub and run:
+Now [prepare a bootable kernel for your hardware](KERNEL.md). Reboot into GRUB and run:
 
 ```shell
 > linux (hdX,gptY)/boot/kernel ro root=/dev/xxx
 > boot
 ```
 
-where X, Y - GRUB disk and partition numbers for /dev/xxx. 
-After a successful boot, switch into tty5, there will be a root prompt.
+where X, Y are the GRUB disk and partition numbers for /dev/xxx.
+After a successful boot, switch to tty5, the root prompt will appear.
 
 ```shell
 . /etc/session
 ```
 
-Now we have some useful utilities in PATH from /ix/realm/root.
+We now have some useful utilities in the PATH from /ix/realm/root.
 
 ```shell
 cd /home/ix/ix
@@ -126,30 +129,30 @@ cd /home/ix/ix
 ./ix mut system
 ```
 
-Shell will relaunch thereafter. Actually, after any modification of the system realm, runit will reload the whole supervised process tree.
+After this, the shell will restart. In fact, after any change to the system realm, the init will restart the entire supervised process tree.
 
 ```shell
 cd /home/ix/ix
 ./ix mut $(./ix list)
 ```
 
-Rebuild the world and [add a whole new user without sudo capability](https://github.com/stal-ix/stal-ix.github.io/blob/main/ETC.md#add-user)<br>
+Rebuild the world and [add a completely new user without sudo capability](https://stal-ix.github.io/ETC#add-user).<br>
 
 Try logging in from tty1.
 
-What next: 
+What's next: 
 
-Add some uniqueness into system, without this some packages refuse to install:
+Add uniqueness to the system, without it some packages refuse to install:
 
 ```shell
 ./ix mut system --seed="$(cat /dev/random | head -c 1000 | base64)"
 ```
 
-[bootloader](GRUB.md)<br>
-[setup wifi](WIFI.md)<br>
-[some quirks](CAVEATS.md)<br>
-[system configuration](ETC.md)<br>
-[user login](LOGIN.md)
+[Bootloader](GRUB.md)<br>
+[Set up Wi-Fi](WIFI.md)<br>
+[Some oddities](CAVEATS.md)<br>
+[System configuration](ETC.md)<br>
+[User login](LOGIN.md)
 
 <!-- {% endraw %} -->
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -148,7 +148,8 @@ Add some uniqueness into system, without this some packages refuse to install:
 [bootloader](GRUB.md)<br>
 [setup wifi](WIFI.md)<br>
 [some quirks](CAVEATS.md)<br>
-[system configuration](ETC.md)
+[system configuration](ETC.md)<br>
+[user login](LOGIN.md)
 
 <!-- {% endraw %} -->
 

--- a/IX.md
+++ b/IX.md
@@ -4,7 +4,7 @@
 > [FS.md](FS.md)<br>
 
 
-**IX** package manager can be used standalone on any supported OS, or as a base package manager on Linux **stal/IX** distribution.
+**IX** package manager can be used [standalone on any supported OS](IX_standalone.md), or as a base package manager on Linux **stal/IX** distribution.
 
 This document describes the **IX** usage as part of **stal/IX**.
 

--- a/IX.md
+++ b/IX.md
@@ -1,20 +1,20 @@
 # IX package manager
 
-> Prereq:<br>
+> Prerequisites:<br>
 > [FS.md](FS.md)<br>
 
 
-**IX** package manager can be used [standalone on any supported OS](IX_standalone.md), or as a base package manager on Linux **stal/IX** distribution.
+The **IX** package manager can be used [standalone on any supported OS](IX_standalone.md) or as the base package manager in the **stal/IX** Linux distribution.
 
-This document describes the **IX** usage as part of **stal/IX**.
+This document describes the use of **IX** as part of **stal/IX**.
 
-The **stal/IX** on disk installing guide you can read in [INSTALL.md](INSTALL.md)
+You can read the installation guide for **stal/IX** on-disk at [INSTALL.md](INSTALL.md).
 
 ## Basic concepts
 
-*Package* - one folder contents in /ix/store directory.
+A *package* is the contents of a single folder in the /ix/store directory.
 
-Here, for example, is bzip2 package contents:
+For example, here are the contents of the bzip2 package:
 
 ```shell
 ix# find /ix/store/0GsKotnAh74LIcvO-bin-bzip2/
@@ -35,9 +35,9 @@ ix# find /ix/store/0GsKotnAh74LIcvO-bin-bzip2/
 /ix/store/0GsKotnAh74LIcvO-bin-bzip2/touch
 ```
 
-All packages form a content addressable store, substantially similar to the same structure in nixos and guix.
+All packages form a content-addressable store, essentially similar to the same structure in NixOS and Guix.
 
-*Realm* - also a package, it contains symlinks to other packages:
+A *realm* is also a package that contains symbolic links to other packages:
 
 ```shell
 ix# find /ix/store/0Q4rkMy8J8D1WTVn-rlm-system
@@ -60,7 +60,7 @@ ix# find /ix/store/0Q4rkMy8J8D1WTVn-rlm-system
 /ix/store/0Q4rkMy8J8D1WTVn-rlm-system/touch
 ```
 
-Some realms have anchor links that mark the current (used) version of some realm:
+Some realms have anchor links that mark the current (used) version of a certain realm:
 
 ```shell
 ix# ls -la /ix/realm/
@@ -73,13 +73,13 @@ lrwxrwxrwx pg -> /ix/store/QC6vXQZNfLfhT4t1-rlm-pg
 lrwxrwxrwx system -> /ix/store/PIYCjYiLy1AIxVVl-rlm-system
 ```
 
-To use the contents of some realm, just add this realm to your PATH:
+To use the contents of a realm, simply add that realm to your PATH:
 
 ```shell
 ix# export PATH="/ix/realm/boot/bin:${PATH}"
 ```
 
-To make this setting happen automatically, in the first line of your session script, do:
+To make this setting happen automatically, in the first line of your session script, add:
 
 ```shell
 . /etc/session
@@ -87,50 +87,50 @@ To make this setting happen automatically, in the first line of your session scr
 
 ## Using IX
 
-To start using **IX** clone it from github.
+To start using **IX**, clone it from GitHub.
 
 ```shell
 ix# git clone https://github.com/stal-ix/ix
 ix# export PATH=${PWD}/ix:${PATH}
 ```
 
-Any user with sudo configured can install packages on the system. Thanks to the content addressable store usage, different versions of packages will not overlap with each other. Different users may use different **IX** repository versions. The recommended way to customize the system for yourself - clone the repository on github, and make the necessary changes to your branch. Perhaps, someday there'll be support for overlays.
+Any user with sudo configured can install packages on the system. Using a content-addressable store, different versions of packages will not overlap. Different users can use different versions of the **IX** repository. The recommended way to customize the system is to clone the repository on GitHub and make the necessary changes to your branch. Perhaps someday there will be support for overlays.
 
 The basic command when using **IX** is `ix mut`.
 
-Install the sway program in realm gui:
+Install Sway in the gui realm:
 
 ```shell
 ix# ix mut gui bin/sway
 ```
 
-Install the sway program in realm gui, specifying that it should use the 3d accelerated driver for AMD GPU:
+Install Sway in the gui realm, specifying that it should use the 3D acceleration driver for AMD GPU:
 
 ```shell
 ix# ix mut gui bin/sway --mesa_driver=radv
 ```
 
-[See](ACCEL.md) also for a more detailed introduction to the subject of 3D acceleration in **stal/IX**.
+For a more detailed introduction to 3D acceleration in **stal/IX**, see [ACCEL.md](ACCEL.md).
 
-Let's say that all programs in realm gui should use AMD GPU:
+Let's assume that all programs in the gui realm should use AMD GPU:
 
 ```shell
 ix# ix mut gui --mesa_driver=radv
 ```
 
-And remove mesa_driver flag, for software 3D:
+And remove the mesa_driver flag for software 3D:
 
 ```shell
 ix# ix mut system --mesa_driver=-
 ```
 
-Add a browser to the realm gui:
+Add a browser to the gui realm:
 
 ```shell
 ix# ix mut gui bin/epiphany
 ```
 
-We are fed up with sway and want to use wayfire:
+We are tired of Sway and want to use Wayfire:
 
 ```shell
 ix# ix mut gui -bin/sway bin/wayfire
@@ -142,35 +142,35 @@ Update all installed programs in the gui realm:
 ix# ix mut gui
 ```
 
-By the way, to manipulate your named realm, you can simply omit its name from ix cli:
+By the way, to control your named realm, you can simply exclude its name from the IX CLI:
 
 ```shell
 ix# ix mut bin/telegram/desktop
 ix# ix mut -bin/epiphany +bin/links
 ```
 
-The command can manipulate any number of realms at the same time. The ambiguity is resolved by the fact that realm names cannot contain /, and package names always contain it:
+The command can manipulate any number of realms simultaneously. The ambiguity is eliminated by the fact that realm names cannot contain /, but package names always do:
 
 ```shell
 ix# ix mut gui +bin/dosbox -bin/qemu tui +bin/links
 ```
 
-Flags you specify with `--`, apply to the realm if no package was previously specified within that realm, otherwise to the package:
+Flags you specify with `--` apply to the realm if a package has not previously been specified in that realm, otherwise to the package:
 
 ```shell
 ix# ix mut --mesa_driver=radv +bin/sway --mesa_driver=iris
 ```
 
-With this command, we said that we need to add a flag to the user realm for AMD GPU usage, but we want to use sway with Intel GPU.
+With this command we specified that we need to add a flag in the user realm to use AMD GPU, but we want to use Sway with Intel GPU.
 
 *Important!*<br>
-Within a single command, all changes to one realm happen atomically, but anchor pointers to the realm themselves can happen in any order.
+Within a single command, all changes to a single realm occur atomically, but the anchoring of pointers to the realm itself can occur in any order.
 
 ---
 
 *Exercise*
 
-Explain yourself what the following commands do:
+Explain to yourself what the following commands do:
 
 ```shell
 ix# ix mut A bin/P --X=Y bin/P --X=Z -bin/P
@@ -196,36 +196,36 @@ Version: ImageMagick 7.1.0-58 Q16-HDRI aarch64
     https://imagemagick.org
 ```
 
-The example shows how to run a program built under aarch64 on x86_64 using qemu.
+The example shows how to run a program built for aarch64 on x86_64 using QEMU.
 
 `ix let`
 
-This command does everything the same as `ix mut`, but doesn't switch the anchor link. The command is useful to inspect the contents of the resulting realm before switching.
+This command does the same as `ix mut`, but does not switch the anchor link. The command is useful for checking the contents of the resulting realm before switching.
 
 `ix build`
 
-It's `ix let` over a temporary (ephemeral) realm. The command is useful for reviewing the way some set of packages (can be one) will look like in a freshly created realm, without flags and other environments.
+This is `ix let` over a temporary (ephemeral) realm. The command is useful for seeing how some set of packages (maybe just one) would look in a freshly created realm, without flags and other environments.
 
 `ix gc`
 
-The command finds all unused packages in /ix/store/ and moves them to the /ix/trash/ folder for asynchronous removal. A package is considered unused if there is no path to it from anchor realms in /ix/realm/.
+The command finds all unused packages in /ix/store/ and moves them to the /ix/trash/ folder for asynchronous removal. A package is considered unused if there is no path to it from the anchor realms in /ix/realm/.
 
 `ix list`
 
-View a list of all realms, or installed packages (with flags) in a specific realm.
+View a list of all realms or installed packages (with flags) in a specific realm.
 
-A list of all available packages can be found at [https://github.com/stal-ix/ix/tree/main/pkgs](https://github.com/stal-ix/ix/tree/main/pkgs), or in the pkgs/ folder in your clone of the main repository.
+A list of all available packages can be found at [https://github.com/stal-ix/ix/tree/main/pkgs](https://github.com/stal-ix/ix/tree/main/pkgs) or in the pkgs/ folder in your clone of the main repository.
 
 `ix mut $(ix list)`
 
-This command is used for all realms updating.
+This command is used to update all realms.
 
-There're a number of commands in **IX** that are made as standalone scripts and aren't part of the kernel. For example, because they are not implemented well enough in general, or their semantics aren't well developed enough.<br>
-These commands are available through the `ix tool`:
+There are a number of commands in **IX** that are implemented as separate scripts and are not part of the core. For example, because they are not well implemented as a whole or their semantics are not well developed.<br>
+These commands are available through `ix tool`:
 
 `ix tool list` - show all available commands.
 
-Search for the wanted package by name:
+Search for a wanted package by name:
 
 ```shell
 ix# ix tool listall | grep ssh

--- a/IX_standalone.md
+++ b/IX_standalone.md
@@ -1,11 +1,11 @@
 # Using IX as a standalone package manager
 
-> Prereq:<br>
+> Prerequisites:<br>
 > [IX.md](IX.md)<br>
 
 You can use IX as a standalone package manager.
 
-Let's do some preparations:
+Let's make some preparations:
 ```
 $ mkdir ~/ix_root
 $ export IX_ROOT=${HOME}/ix_root
@@ -13,21 +13,21 @@ $ sudo apt install g++
 $ sudo apt install git
 ```
 
-One can use the stable branch of IX:
+You can use the stable branch of IX:
 ```
 $ git clone https://github.com/stal-ix/ix
 ```
-Or you can choose to use the development branch:
+Or you can use the development branch:
 ```
 $ git clone https://github.com/pg83/ix
 ```
 
-Now we need our system to know about IX binary path:
+Now we need our system to know about the IX binary path:
 ```
 $ export PATH=${PWD}/ix:${PATH}
 ```
 
-So let's try to check IX's nano version:
+Let's try to check the version of nano from IX:
 ```
 $ ix run bin/nano -- nano --version
 TOUCH /home/spiage/ix_root/store/IVNnNzFRjwyXtgNF-rlm-ephemeral/touch
@@ -35,13 +35,13 @@ TOUCH /home/spiage/ix_root/store/IVNnNzFRjwyXtgNF-rlm-ephemeral/touch
  (C) 2023 the Free Software Foundation and various contributors
  Compiled options: --enable-utf8
 ```
-And Debian's nano:
+And nano from Debian:
 ```
 $ nano --version
  GNU nano, version 7.2
  (C) 2023 the Free Software Foundation and various contributors
  Compiled options: --disable-libmagic --enable-utf8
 ```
-As you can see you can do it on any system with regular user and with only g++ and git installed.
+As you can see, this can be done on any system with a regular user, where only g++ and git are installed.
 
-First run of *$ ix run bin/nano -- nano --version* takes some time to build all the tools IX need in.
+The first time you run `$ ix run bin/nano -- nano --version` takes some time because it needs to build all the necessary tools.

--- a/IX_standalone.md
+++ b/IX_standalone.md
@@ -1,48 +1,47 @@
-Hi!
+# Using IX as a standalone package manager
 
-Today I am decide to try IX as a standalone package manager.
+> Prereq:<br>
+> [IX.md](IX.md)<br>
 
-I have:
+You can use IX as a standalone package manager.
 
-Small libvirt KVM with freshly installed Debian (only ssh + standart tools was installed from debian-12.7.0-amd64-netinst.iso), 28 CPU, 64K RAM, 100Gb ssd, 1 NIC with NAT
-
-
-After login to VM let's do some preparations:
+Let's do some preparations:
 ```
 $ mkdir ~/ix_root
 $ export IX_ROOT=${HOME}/ix_root
 $ sudo apt install g++
 $ sudo apt install git
 ```
-One can use the stable version of IX
+
+One can use the stable branch of IX:
 ```
 $ git clone https://github.com/stal-ix/ix
 ```
-But I'll use dev
+Or you can choose to use the development branch:
 ```
 $ git clone https://github.com/pg83/ix
 ```
+
 Now we need our system to know about IX binary path:
 ```
 $ export PATH=${PWD}/ix:${PATH}
 ```
+
 So let's try to check IX's nano version:
 ```
 $ ix run bin/nano -- nano --version
 TOUCH /home/spiage/ix_root/store/IVNnNzFRjwyXtgNF-rlm-ephemeral/touch
- GNU nano, версия 7.2
+ GNU nano, version 7.2
  (C) 2023 the Free Software Foundation and various contributors
- Параметры сборки: --enable-utf8
+ Compiled options: --enable-utf8
 ```
-And debian's nano:
+And Debian's nano:
 ```
 $ nano --version
- GNU nano, версия 7.2
+ GNU nano, version 7.2
  (C) 2023 the Free Software Foundation and various contributors
- Параметры сборки: --disable-libmagic --enable-utf8
+ Compiled options: --disable-libmagic --enable-utf8
 ```
-As we can see we can do it on any system with regular user and with only g++ and git installed
+As you can see you can do it on any system with regular user and with only g++ and git installed.
 
-Have a nice day :0)
-
-P.S. First run of *$ ix run bin/nano -- nano --version* took some time to build all the tools IX need in
+First run of *$ ix run bin/nano -- nano --version* takes some time to build all the tools IX need in.

--- a/KERNEL.md
+++ b/KERNEL.md
@@ -1,26 +1,27 @@
 # Kernel
 
-> Prereq:<br>
+> Prerequisites:<br>
 > [FS.md](FS.md)<br>
 > [IX.md](IX.md)<br>
 
-
 **_Disclaimer:_**<br>
-*This guide is not for the faint of heart! It assumes that you have an idea of what a statically linked kernel is and know how to build it for your hardware in some source-based distro.*
+*This guide is not for the faint of heart! It assumes that you have some idea of ​​what a statically linked kernel is, and how to build one for your hardware in a source-based distribution.*
 
-Also you can use any suitable kernel for your hardware, with:
+*This page was last updated on January 22, 2024 (as of May 19, 2025) and may not be up to date (e.g., pkgs/bin/kernel/kernels.json was removed on [January 27, 2024](https://github.com/stal-ix/ix/commit/e167fc600108b4874887e708a09b229765445206)).*
 
-* MGLRU enabled
-* transparent huge pages enabled
-* cgroupsv2
-* all usual pseudo fs, like proc, debugfs, sysfs, devptsfs, tmpfs
-* zram
-* statically linked
-* and with built in firmware
+Also you can use any suitable kernel for your hardware that:
+
+* has MGLRU enabled
+* has transparent huge pages enabled
+* has cgroupsv2
+* has all the usual pseudo filesystems like proc, debugfs, sysfs, devptsfs, tmpfs
+* has zram
+* is statically linked
+* and has firmware built-in
 
 ---
 
-This guide implies ix package manager in your PATH:
+This guide assumes that the IX package manager is in your PATH:
 
 ```shell
 ix# export PATH=/mnt/ix/home/ix/ix:${PATH}   # assumes we are in stal/IX installer, before reboot
@@ -30,12 +31,12 @@ ix# ix list
 ```
 ---
 
-The guide intends to build a kernel that contains all the components necessary for operation.
+The goal of this guide is to build a kernel that contains all the components needed to run it.
 
-First, you need to know the list of modules for your hardware support.
+First, you need to know the list of modules that your hardware supports.
 
-You can download some conventional distro with a working hardware auto-detection system to do this.<br>
-It needs to execute:
+To do this, you can download any regular distribution with a working automatic hardware detection system.<br>
+You need to do the following:
 
 ```shell
 ubuntu# lspci -k
@@ -57,9 +58,9 @@ ubuntu# lspci -k
 ...
 ```
 
-The last column - a list of modules that we need. Write them down.
+The last column is a list of modules we need. Write them down.
 
-Next, we need to prepare a directory with kernel sources for which we are building a config. Let's say we want to use kernel 6.0:
+Next, we need to prepare a directory with the kernel sources for which we are building a config. Let's say we want to use kernel 6.0:
 
 ```shell
 ix# mkdir kernel
@@ -76,7 +77,7 @@ ix# tar xf linux-6.7.1.tar.xz
 ix# cd linux-6.7.1
 ```
 
-Copy old kernel config to our tree:
+Let's copy the old kernel configuration into our tree:
 
 ```shell
 ix# cp $(dirname $(which ix))/pkgs/bin/kernel/configs/cfg_6_6_0 ./.config
@@ -88,20 +89,20 @@ Run the kernel configurator:
 ix run set/menuconfig -- make HOSTCC=cc menuconfig
 ```
 
-You need to find all the modules from the list above in the configurator (it has a search!) and add them to the configuration.
+You need to find all the modules from the list above in the configurator (there is a search!) and add them to the configuration.
 
 ---
-Herewith:
+That being said:
 
  * Don't forget to add all the necessary buses for your devices (USB, I2C, PCIe, NVMe, etc.).
- * Some drivers require firmware. They'll need to be added to ix.sh for your kernel, as done here: [https://github.com/stal-ix/ix/blob/main/pkgs/bin/kernel/6/0/slot/vbox/ix.sh#L9](https://github.com/stal-ix/ix/blob/main/pkgs/bin/kernel/6/0/slot/vbox/ix.sh#L9).<br>
-  *Pro tip:* run `dmesg | grep firmware` on running system for information about missing firmware!
- * Read how to build a kernel generally in a source-based distro - [https://wiki.gentoo.org/wiki/Kernel/Configuration](https://wiki.gentoo.org/wiki/Kernel/Configuration).
- * Don't forget to add cgroup, user namespaces, network namespaces support for your kernel!
+ * Some drivers require firmware. They'll need to be added to ix.sh for your kernel, as done here: [https://github.com/stal-ix/ix/blob/0b454258670ba4a4bc3fba6d416801d55c73467d/pkgs/bin/kernel/6/0/slot/vbox/ix.sh#L9](https://github.com/stal-ix/ix/blob/0b454258670ba4a4bc3fba6d416801d55c73467d/pkgs/bin/kernel/6/0/slot/vbox/ix.sh#L9).<br>
+  *Pro tip:* Run `dmesg | grep firmware` on a running system to get information about the missing firmware!
+ * Read how to build a kernel in general in a source-based distribution - [https://wiki.gentoo.org/wiki/Kernel/Configuration](https://wiki.gentoo.org/wiki/Kernel/Configuration).
+ * Don't forget to add support for cgroups, user namespaces, network namespaces to your kernel!
 
 ---
 
-Alternatively, you can combine previous commands into one:
+Alternatively, you can combine the previous commands into one:
 
 ```shell
 ...
@@ -109,11 +110,11 @@ ix# cd linux-6.7.1
 ix# ix tool reconf $(dirname $(which ix))/pkgs/bin/kernel/configs/cfg_6_6_0
 ```
 
-Mostly, to understand what needs to be included in the kernel config for a particular device operation, it helps to search the Internet with the module's name and a link to Gentoo/Arch as they have the largest knowledge base on the subject:
+Most often, to understand what needs to be included in the kernel configuration for a particular device operation, it is useful to search the web for the module name and the Gentoo/Arch link, as they have the largest knowledge base on the topic:
 
  * Here, for example, is a list of what needs to be done to get AMD GPU support operating - [https://wiki.gentoo.org/wiki/AMDGPU](https://wiki.gentoo.org/wiki/AMDGPU).
 
-After the kernel is configured, copy the modified config to the base:
+After configuring the kernel, copy the modified configuration to the base:
 
 ```shell
 ix# cp .config $(dirname $(which ix))/pkgs/bin/kernel/configs/cfg_6_6_0
@@ -127,7 +128,7 @@ ix# ls /bin/kernel-*
 /bin/kernel-6-7-1...
 ```
 
-Remember that path, you will need it later, in GRUB cli or in grub.cfg.
+Remember that path, you will need it later in GRUB CLI or in grub.cfg.
 
 Alternatively, you can use a separate realm for the bootstrap kernel:
 
@@ -137,4 +138,4 @@ ix# ls /ix/realm/kernel/bin/kernel-*
 /ix/realm/kernel/bin/kernel-6-7-1-slot0
 ```
 
-Remember that path, you will need it later, in GRUB cli or in grub.cfg.
+Remember that path, you will need it later in GRUB CLI or in grub.cfg.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2023 - 2025 Anton Samokhvalov and stal/IX contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LOGIN.md
+++ b/LOGIN.md
@@ -1,39 +1,27 @@
 # Login
 
-> Warning: everything described here is a moving target and subject to change.
+> Disclaimer: Everything described here is a moving target and is subject to change.
 
-It is assumed that for each user ${USER}, there is a realm ${USER}, located at /ix/realm/${USER}.<br> 
-It is also assumed that this realm contains all the programs necessary for work and logging into the system.<br> 
+It is assumed that for each user ${USER} there is a realm ${USER} located at /ix/realm/${USER}.<br> 
+It is also assumed that this realm contains all the programs needed to operate and log in to the system.<br> 
 
-An example of what may be found in a user realm: https://github.com/stal-ix/ix/blob/main/pkgs/set/pg/ix.sh.
+An example of what you might find in a user realm: [https://github.com/stal-ix/ix/blob/main/pkgs/set/pg/ix.sh](https://github.com/stal-ix/ix/blob/main/pkgs/set/pg/ix.sh).
 
-For all users allowed to login, the /bin/session script is set as the shell:
+For all users who are allowed to log in, the /bin/session script is set as the shell:
 
 ```
 pg# cat /etc/passwd  | grep sess
 pg:redacted:10000:10000:none:/home/pg:/bin/session
 ```
 
-This script configures the user environment, some environment variables, creates temporary folders for the user, etc.:
+This script sets up the user environment, some environment variables, creates temporary folders for the user, etc.:
 
-https://github.com/stal-ix/ix/blob/main/pkgs/bin/session/scripts/session
+[https://github.com/stal-ix/ix/blob/main/pkgs/bin/session/scripts/session](https://github.com/stal-ix/ix/blob/main/pkgs/bin/session/scripts/session)
 
-This script also exports environment settings from the user realm:
-
-```
-. /ix/realm/${USER}/etc/env
-```
-
-Some programs may configure the necessary environment for their functionality when installed in the user realm:
-
-https://github.com/pg83/ix/blob/main/pkgs/lib/gtk/4/env/ix.sh
-
-(therefore, if you want to use a different login scheme, you need to ensure that this file is read during the login process)
-
-Then, the script passes control to user-session, which is the configuration point, meaning you can replace this script with your own.
+The script then passes control to `user-session`, which is a configuration point, meaning you can replace this script with your own.
 
 ```
 exec user-session
 ```
 
-By default, `user-session` passes control to ${HOME}/.session, which is also a configuration point. Here you can start session programs like ssh-agent and launch the Wayland compositor you are using.
+By default, `user-session` passes control to ${HOME}/.session, which is also a configuration point. This is where you can run session programs like ssh-agent and start the Wayland compositor you use.

--- a/MIRROR.md
+++ b/MIRROR.md
@@ -2,13 +2,13 @@
 
 **List of source mirrors used to build stal/IX:**
 
-https://github.com/pg83/ix/blob/main/pkgs/die/scripts/mirrors.txt
+[https://github.com/pg83/ix/blob/main/pkgs/die/scripts/mirrors.txt](https://github.com/pg83/ix/blob/main/pkgs/die/scripts/mirrors.txt)
 
-You can help the project by hosting such a mirror and making it available to the world!
+You can help the project by hosting such a mirror and making it available to the whole world!
 
-The structure of the mirror is very simple - it is a single-level list of files, and the name of each file is sha256sum of the data contained in this file.
+The structure of the mirror is very simple - it is a single-level list of files, and the name of each file is the SHA-256 sum of the data contained in that file.
 
-So, for example, you can copy all the contents of one of the mirrors and make a copy available on the Internet.
+For example, you can copy the entire contents of one of the mirrors and make the copy available on the Internet.
 
 Or you can run a ready-made script in cron, for example, once an hour:
 
@@ -34,7 +34,7 @@ git pull
 
 ([from @vvzvlad](https://gist.github.com/pg83/4bdb11a2ca3602d949db26b4b2a66781?permalink_comment_id=4687160#:~:text=Commands%20for%20debian,cron.d/ix_recache))
 
-Commands for debian vm (root user):
+Commands for Debian VM (root user):
 
 ```
 apt install make git python3 wget git nginx -y
@@ -51,5 +51,4 @@ echo '/root/ix/ix recache /var/www/html/ >> "$log_file" 2>&1' >> /root/ix_recach
 echo "0 */4 * * * /bin/sh /root/ix_recache.sh > /dev/null 2>&1" > /etc/cron.d/ix_recache
 ```
 
-**After populating the cache directory, send a PR to add the new mirror to 
-https://github.com/pg83/ix/blob/main/pkgs/die/scripts/mirrors.txt**
+**Once the cache directory is populated, submit a PR to add the new mirror at https://github.com/pg83/ix/blob/main/pkgs/die/scripts/mirrors.txt**

--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@
 [Website license](LICENSE.md)
 
 ----------
+#### 2025-05-19: A new stal/IX website is under construction, which will have better navigation. It will be made available in a couple of months.
 #### stal/IX 2.0: Rust in a [completely static environment](https://t.me/stal_ix/294) 
 #### We are pleased to [officially announce](RELEASE.md) the release of the alpha version of stal/IX!

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <img alt="logo" src="https://raw.githubusercontent.com/stal-ix/stal-ix.github.io/main/images/stalix_light.png" width="250px" height="100px">
 
-**[stal/IX](STALIX.md)** - statically linked, source based, [bootstrapped](https://bootstrappable.org/) [rolling](https://en.wikipedia.org/wiki/Rolling_release) Linux, based on [IX](IX.md) package manager:
+**[stal/IX](STALIX.md)** is a statically linked, source-based, [bootstrapped](https://bootstrappable.org/) [rolling](https://en.wikipedia.org/wiki/Rolling_release) Linux distribution, based on the [IX](IX.md) package manager:
 
-* clang
-* full static
-* musl on linux
-* reproducible builds
-* pure builds if possible
-* first class cross-compilation
-* no(almost) binary seeds, only compiler and dash
+* Clang
+* Fully static
+* musl on Linux
+* Reproducible builds
+* Clean builds if possible
+* First class cross-compilation
+* There are (almost) no binary seeds, just a compiler and dash
 
 [Why](CASES.md)<br>
 [Blog](https://medium.com/@anton_samokhvalov)<br>
@@ -16,10 +16,10 @@
 [Support](https://t.me/stal_ix)<br>
 [Download](https://github.com/stal-ix/ix)<br>
 [Add a mirror](MIRROR.md)<br>
-[Install instructions](INSTALL.md)<br>
+[Installation instructions](INSTALL.md)<br>
 [Packaging guide](PKG.md)<br>
 [Documentation style guide](GUIDE.md)
 
 ----------
 #### stal/IX 2.0: Rust in a [completely static environment](https://t.me/stal_ix/294) 
-#### We are pleased to [officially announce](RELEASE.md) the alpha release of stal/IX!
+#### We are pleased to [officially announce](RELEASE.md) the release of the alpha version of stal/IX!

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 [Add a mirror](MIRROR.md)<br>
 [Installation instructions](INSTALL.md)<br>
 [Packaging guide](PKG.md)<br>
-[Documentation style guide](GUIDE.md)
+[Documentation style guide](GUIDE.md)<br>
+[Website license](LICENSE.md)
 
 ----------
 #### stal/IX 2.0: Rust in a [completely static environment](https://t.me/stal_ix/294) 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
 [Support](https://t.me/stal_ix)<br>
 [Download](https://github.com/stal-ix/ix)<br>
 [Add a mirror](MIRROR.md)<br>
-[Install instructions](INSTALL.md)
+[Install instructions](INSTALL.md)<br>
+[Packaging guide](PKG.md)<br>
+[Documentation style guide](GUIDE.md)
 
 ----------
 #### stal/IX 2.0: Rust in a [completely static environment](https://t.me/stal_ix/294) 

--- a/STALIX.md
+++ b/STALIX.md
@@ -1,7 +1,7 @@
 # stal/IX
 
 
-This document contains a regularly replenishing list of **stal/IX** and conventional Linux differences.
+This document contains a regularly updated list of differences between **stal/IX** and regular Linux.
 
 ## Minimalism
 
@@ -11,9 +11,9 @@ This document contains a regularly replenishing list of **stal/IX** and conventi
 
 **stal/IX** is not UNIX or Linux in the usual sense of these terms.
 
-**stal/IX** - an attempt to rethink some fundamentals without touching Linux API and ABI.
+**stal/IX** is an attempt to rethink some fundamentals without touching the Linux API and ABI.
 
-One of the **stal/IX** goals - from the very beginning to build the system in such a way that it’s possible to understand how it works, and not only use it conveniently.
+One of the goals of **stal/IX** is to build the system from the ground up in such a way that it is easy to understand how it works, not just easy to use.
 
 [https://wiki.musl-libc.org/alternatives.html](https://wiki.musl-libc.org/alternatives.html)<br>
 [https://github.com/illiliti/libudev-zero](https://github.com/illiliti/libudev-zero)<br>
@@ -25,14 +25,14 @@ One of the **stal/IX** goals - from the very beginning to build the system in su
 [https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard)<br>
 [FS.md](FS.md) 
 
-Overall, the file system will be familiar to those who know Nix/Guix. Atomic updates, multi-versioning - all here!
+In general, the file system will be familiar to those who know Nix/Guix. Atomic updates, multiversioning - it's all here!
 
 ## No systemd
 
 [https://blog.darknedgy.net/technology/2020/05/02/0/](https://blog.darknedgy.net/technology/2020/05/02/0/)<br>
 [https://www.phoronix.com/news/systemd-Git-Stats-2022](https://www.phoronix.com/news/systemd-Git-Stats-2022)
 
-**stal/IX** currently uses runit as the most lightweight solution, perhaps, this will change in the future.
+Currently, **stal/IX** uses a custom init as the most lightweight solution. It formerly used runit, but it was too hard with the content-addressable store.
 
 ## Musl
 
@@ -41,19 +41,19 @@ Overall, the file system will be familiar to those who know Nix/Guix. Atomic upd
 [https://www.phoronix.com/news/Glibc-2.36-EAC-Problems](https://www.phoronix.com/news/Glibc-2.36-EAC-Problems)
 [https://ariadne.space/2021/12/29/glibc-is-still-not-y2038-compliant-by-default/](https://ariadne.space/2021/12/29/glibc-is-still-not-y2038-compliant-by-default/)
 
-Glibc does not fully support static linking. **stal/IX** uses musl for internal needs, and allows to build custom soft with an arbitrary libc on a choice.
+Glibc does not fully support static linking. **stal/IX** uses musl internally and allows userland software to be built with an arbitrary libc of choice.
 
 ## Non-root package management
 
 [IX.md](IX.md) 
 
-All files on the system are IX user-owned, and all package management is done on his behalf.
+All files on the system are owned by user IX, and all package management is performed on its behalf.
 
-Consequence - there is not a single suid binary on the system. Sudo - the thin layer over local ssh daemon, for privilege escalation.
+Consequently, there is not a single suid binary file in the system. Sudo is a thin layer over the local ssh daemon, to increase privileges.
 
 ## Fully supervised process tree
 
-Every process different from init has a parent different from init. All processes that fail to meet this requirement are killed by a specially dedicated background process. To manage services used runit, encouraging this behavior.
+Every process other than init has a parent other than init. All processes that do not meet this requirement are terminated by a specially designated background process. A custom init is used to manage services, encouraging this behavior.
 
 [https://github.com/swaywm/sway/issues/6828](https://github.com/swaywm/sway/issues/6828)<br>
 [https://github.com/stal-ix/ix/blob/main/pkgs/bin/sched/staleprocs/staleprocs.sh](https://github.com/stal-ix/ix/blob/main/pkgs/bin/sched/staleprocs/staleprocs.sh)<br>
@@ -75,26 +75,27 @@ No ld.so!
 
 [https://drewdevault.com/2021/02/02/Anti-Wayland-horseshit.html](https://drewdevault.com/2021/02/02/Anti-Wayland-horseshit.html)
 
-X is dying, and to maintain the efficiency of the IX package base running with X means doing work that one day will have to be thrown out. We don’t have enough resources for that.
+X is dying, and to keep the IX package base efficient, working on X means doing work that will one day have to be thrown away. We don't have enough resources to do that.
 
 ## Login shell
 
 No<br>
 [https://askubuntu.com/questions/866161/setting-path-variable-in-etc-environment-vs-profile](https://askubuntu.com/questions/866161/setting-path-variable-in-etc-environment-vs-profile)
 
-Every user session must start from the login shell, even in ssh daemon.
+Every user session must start from the login shell, even in the ssh daemon.
 
-[Patch for dropbear](https://github.com/stal-ix/ix/blob/main/pkgs/bin/dropbear/ix.sh#L7) to launch all processes, including non-interactive ones, with login shell.
+[Patch for dropbear](https://github.com/stal-ix/ix/blob/main/pkgs/bin/dropbear/ix.sh#L7) to launch all processes, including non-interactive ones, with a login shell.
 
-## Cross-compile by default
+## Cross-compilation by default
 
-All packages are compiled as if host platform != target platform, thus, we achieve that the package base is built for all platforms most of the time. We have a cross-compiling CI for aarch64 and riscv!
+All packages are compiled as if host platform != target platform, so we achieve that the package base is built for all platforms most of the time. We have cross-compiling CI for aarch64 and riscv!
 
 ## File associations
 
-The existing mechanisms for associating programs to file types are complex, fragile, and difficult to integrate into IX realms. https://wiki.archlinux.org/title/XDG_MIME_Applications
+Existing mechanisms for associating programs with file types are complex, fragile, and difficult to integrate into IX realms.<br>
+[https://wiki.archlinux.org/title/XDG_MIME_Applications](https://wiki.archlinux.org/title/XDG_MIME_Applications)
 
-Therefore, stal/IX has its own mechanism for linking programs to file types. It is based on the [xdg-open-dispatch](https://github.com/stal-ix/ix/blob/main/pkgs/bin/xdg/open/scripts/xdg-open-dispatch) script, and changes in upstream to redirect their mechanisms to xdg-open, patch for [epiphany WEB browser](https://github.com/stal-ix/ix/blob/main/pkgs/bin/epiphany/4/ix.sh#L32). 
+Therefore stal/IX has its own mechanism for associating programs with file types. It is based on the [xdg-open-dispatch](https://github.com/stal-ix/ix/blob/main/pkgs/bin/xdg/open/scripts/xdg-open-dispatch) script, and changes in upstream to redirect their mechanisms to xdg-open, such as a patch for the [Epiphany web browser](https://github.com/stal-ix/ix/blob/main/pkgs/bin/epiphany/4/ix.sh#L32). 
 
 [Interaction with upstream](UPSTREAM.md)
 

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -1,6 +1,6 @@
 ## Interaction with upstream
 
-Quite often, upstream is not interested in the ideas inherent in **stal/IX**:
+Quite often, upstream is not interested in the ideas behind **stal/IX**:
 
 * [glib developers actively hinder static linking with glib](https://bugzilla.gnome.org/show_bug.cgi?id=768215#c16);
 * [VTE developers don't care about building with musl](https://gitlab.gnome.org/GNOME/vte/-/issues/72), and [don't answer questions](https://gitlab.gnome.org/GNOME/vte/-/issues/72#note_1415630);
@@ -14,6 +14,6 @@ Quite often, upstream is not interested in the ideas inherent in **stal/IX**:
 * [by default, linux kernel eat CPU cycles on breakfast](https://www.phoronix.com/news/Linux-Default-Mitigations-Off), [we disable it by default](https://github.com/stal-ix/ix/blob/main/pkgs/bin/kernel/t/2/ix.sh#L21);
 * [custom gdk-pixbuf SVG loader, over lunasvg (instead of rsvg)](https://github.com/stal-ix/ix/blob/main/pkgs/lib/lunasvg/gdk/io.cpp).
 
-Therefore, we have to maintain a set of fixes and adjustments for upstream that will never be merged into upstream.
+So we have to maintain a set of fixes and patches for upstream that will never be merged into upstream.
 
-Project goals are more important than the arrogant behavior of some maintainers!
+The goals of the project are more important than the arrogant behavior of some maintainers!

--- a/WIFI.md
+++ b/WIFI.md
@@ -1,4 +1,6 @@
-Fast path:
+# Wi-Fi
+
+Quick way:
 
 ```shell
 user# ix mut bin/iwd/ctl # install iwctl into user realm
@@ -11,4 +13,4 @@ user# iwctl
 > station wlan0 connect <SSID>
 ```
 
-or, alternatively, [detailed description](https://wiki.archlinux.org/title/Iwd#iwctl)
+or, alternatively, [a detailed description](https://wiki.archlinux.org/title/Iwd#iwctl)


### PR DESCRIPTION
Here are some notes that I took along the way:
* The [packaging documentation](https://stal-ix.github.io/PKG), which is an essential guide for stal/IX contributors, isn't referenced by any other page on the website, making it very difficult to find.
* Most grammatical errors and typos were the result of non-native English speakers of Russian origin.
* URLs are never automatically converted to links.
* The [kernel guide](https://stal-ix.github.io/KERNEL) was last updated on January 22, 2024. pkgs/bin/kernel/kernels.json (which is mentioned in the guide) was removed less than a week later.
* Up until this point, the website never had a license. I added an MIT license just like the other stal/IX repos.