### PR TITLE
Update the bootloader, installation, and kernel guides

### DIFF
--- a/GRUB.md
+++ b/GRUB.md
@@ -6,6 +6,8 @@ This text assumes that you know what GRUB is, what it is used for, and have a ge
 (2) [https://wiki.archlinux.org/title/EFI_system_partition](https://wiki.archlinux.org/title/EFI_system_partition)<br>
 (3) [https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface](https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface)<br>
 
+## UEFI
+
 Become root user:
 ```
 $ sudo sh
@@ -38,9 +40,33 @@ Install the bootloader:
 
 Configure GRUB to automatically detect all kernels installed in the system realm:
 ```
-# cat << EOF > /boot/grub/grub.conf
+# cat << EOF > /boot/grub/grub.cfg
 configfile /etc/grub.cfg
 EOF
 # ix mut system bin/kernel/gengrub
 ```
 
+## Legacy BIOS
+
+Become root user:
+```
+$ sudo sh
+```
+
+Install the GRUB bootloader package:
+```
+# ix mut bin/grub/bios
+```
+
+Install the bootloader itself:
+```
+# grub-install --target=i386-pc /dev/xxx
+```
+
+Configure GRUB to automatically detect all kernels installed in the system realm:
+```
+# cat << EOF > /boot/grub/grub.cfg
+configfile /etc/grub.cfg
+EOF
+# ix mut system bin/kernel/gengrub
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,159 +1,19 @@
 # Installation
-<sup> The stal/IX on-disk installation guide </sup>
 
-> Prerequisites:<br>
-> [IX.md](IX.md)<br>
-> [FS.md](FS.md)<br>
+There are two ways to install **stal/IX**. It's up to you on which method you choose:
 
-**_Disclaimer:_**<br>
-*It is recommended that you have at least 100 GB of free storage space to bootstrap stal/IX. Expect this process to take 15 hours or more on some older and/or less powerful hardware, so be patient.*
+* [rootfs installation method](INSTALL_ROOTFS.md)
+  * Advantages:
+    * Recommended for beginners
+    * Allows you to setup a stal/IX installation in almost no time
+    * Requires at least 5 GB of storage space, depending on your kernel configuration
+  * Disadvantages:
+    * Only works on x86 (64-bit)
 
-<!-- {% raw %} -->
-
-Boot the machine from a bootable media, such as an Ubuntu/Fedora/NixOS live CD, and launch a terminal:
-
-```shell
-sudo sh
-```
-
-Install the tools:
-
-```shell
-test -f /usr/bin/parted || yum install parted || apt-get install parted
-# gcc >= 13 can't bootstrap IX right now, so we prefer Clang where possible	
-test -f /usr/bin/g++ || yum install clang lld || yum install g++ || apt-get install g++
-test -f /usr/bin/git || yum install git || apt-get install git
-test -f /usr/bin/make || yum install make || apt-get install make
-```
-
-For general instructions on partitioning a disk, see<br>
-[https://wiki.archlinux.org/title/installation_guide#Partition_the_disks](https://wiki.archlinux.org/title/Installation_guide#Partition_the_disks).<br>
-
-Prepare EXT4 on /dev/xxx using parted, mkfs.ext4, and mount it:
-
-```shell
-mkdir /mnt/ix
-mount /dev/xxx /mnt/ix
-```
-
-Prepare several symbolic links to form the future root filesystem:
-
-```shell
-cd /mnt/ix
-
-ln -s ix/realm/system/bin bin
-ln -s ix/realm/system/etc etc
-ln -s / usr
-
-mkdir -p home/root var sys proc dev
-```
-
-Add a symbolic link to trick the **IX** package manager:
-
-```shell
-ln -s /mnt/ix/ix /ix
-```
-
-Add user "**ix**" who will own all packages on the system (note: UID 1000 is important):
-
-```shell
-useradd -ou 1000 ix
-```
-
-Prepare a managed directory owned by user **ix** in /ix, /ix/realm, etc.:
-
-```shell
-mkdir ix
-chown ix ix
-```
-
-Prepare the home directory of user **ix**, owned by **ix**:
-
-```shell
-mkdir home/ix
-chown ix home/ix
-```
-
-Change user to **ix** and run all commands as user **ix**:
-
-```shell
-su ix
-cd /mnt/ix
-```
-
-Download the **IX** package manager, which will be used later, as the ix user before rebooting and as the root user after rebooting:
-
-```shell
-# we don't want to change our CWD
-(cd home/ix; git clone https://github.com/stal-ix/ix.git)
-```
-
-Some oddities:
-
-```shell
-# like tmp dir, so realm symlink can be modified only by its creator/owner
-# it is important who create/own system realm, because only they can operate it
-# sudo chown {{username}} /ix/realm/system will help, iff one wants to transfer ownership 
-mkdir -m 01777 ix/realm
-```
-
-And run the **IX** package manager to populate the root filesystem with bootstrap tools:
-
-```shell
-cd home/ix/ix
-export IX_ROOT=/ix
-export IX_EXEC_KIND=local
-./ix mut system set/stalix --failsafe --mingetty etc/zram/0
-./ix mut root set/install
-./ix mut boot set/boot/all
-```
-
-Now [prepare a bootable kernel for your hardware](KERNEL.md). Reboot into GRUB and run:
-
-```shell
-> linux (hdX,gptY)/boot/kernel ro root=/dev/xxx
-> boot
-```
-
-where X, Y are the GRUB disk and partition numbers for /dev/xxx.
-After a successful boot, switch to tty5, the root prompt will appear.
-
-```shell
-. /etc/session
-```
-
-We now have some useful utilities in the PATH from /ix/realm/root.
-
-```shell
-cd /home/ix/ix
-# very important step, rebuild system realm
-./ix mut system
-```
-
-After this, the shell will restart. In fact, after any change to the system realm, the init will restart the entire supervised process tree.
-
-```shell
-cd /home/ix/ix
-./ix mut $(./ix list)
-```
-
-Rebuild the world and [add a completely new user without sudo capability](https://stal-ix.github.io/ETC#add-user).<br>
-
-Try logging in from tty1.
-
-What's next: 
-
-Add uniqueness to the system, without it some packages refuse to install:
-
-```shell
-./ix mut system --seed="$(cat /dev/random | head -c 1000 | base64)"
-```
-
-[Bootloader](GRUB.md)<br>
-[Set up Wi-Fi](WIFI.md)<br>
-[Some oddities](CAVEATS.md)<br>
-[System configuration](ETC.md)<br>
-[User login](LOGIN.md)
-
-<!-- {% endraw %} -->
-
+* [source installation method](INSTALL_SOURCE.md)
+  * Advantages:
+    * Recommended for advanced users
+    * Works on any architecture supported by the Linux kernel, musl, and LLVM
+  * Disavantages:
+    * Can take 15 hours or more on some older and/or less powerful hardware
+    * Recommended to have at least 100 GB of storage space

--- a/INSTALL_ROOTFS.md
+++ b/INSTALL_ROOTFS.md
@@ -1,0 +1,89 @@
+# Installation from rootfs
+<sup> The stal/IX on-disk installation guide from a rootfs tarball </sup>
+
+> Prerequisites:<br>
+> [IX.md](IX.md)<br>
+> [FS.md](FS.md)<br>
+
+<!-- {% raw %} -->
+
+Boot the machine from a bootable media, such as an Ubuntu/Fedora/NixOS live CD, and launch a terminal:
+
+```shell
+sudo sh
+```
+
+Install the tools:
+
+```shell
+test -f /usr/bin/parted || yum install parted || apt-get install parted
+test -f /usr/bin/wget || yum install wget2 || apt-get install wget
+test -f /usr/bin/tar || yum install tar || apt-get install tar
+test -f /usr/bin/xz || yum install xz || apt-get install xz-utils
+```
+The exact commands for installing `parted`, `wget`, `tar`, and `xz` will depend on the distribution that you use, but the above should work on Fedora, Red Hat Enterprise Linux, Debian, and their derivatives.
+
+For general instructions on partitioning a disk, see<br>
+[https://wiki.archlinux.org/title/installation_guide#Partition_the_disks](https://wiki.archlinux.org/title/Installation_guide#Partition_the_disks).<br>
+
+Prepare EXT4 (or any other file system) on /dev/xxx using `parted` (you can also use `fdisk` or `cfdisk`), `mkfs.ext4` (or the equivalent command for your file system), and mount it:
+
+```shell
+mkdir /mnt/ix
+mount /dev/xxx /mnt/ix
+```
+
+Download the latest stal/IX rootfs tarball from [here](https://github.com/stal-ix/stalix/releases/latest) (e.g. https://github.com/stal-ix/stalix/releases/download/20250620/stalix-x86_64-20250620.tar.xz) and extract it:
+
+```shell
+cd /mnt/ix
+
+wget https://github.com/stal-ix/stalix/releases/download/20250620/stalix-x86_64-20250620.tar.xz
+tar -xpJf stalix-*-*.tar.xz
+```
+
+Create a "tmp" directory in the root filesystem (required for configuring a Linux kernel):
+
+```shell
+mkdir tmp
+```
+
+And `pivot_root` inside of the root filesystem (`chroot` doesn't work with `unshare` used by **IX**):
+
+```shell
+mkdir old-root
+pivot_root . old-root
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount --rbind old-root/dev /dev
+mount -t tmpfs -o mode=1777 tmpfs /dev/shm
+cp old-root/etc/resolv.conf /var/run/resolvconf/
+. /etc/env
+```
+
+Now [prepare a bootable kernel for your hardware](KERNEL.md) and [install the GRUB bootloader](GRUB.md). Reboot into GRUB and select the menu entry corresponding to your kernel. After a successful boot, switch to tty5, the root prompt will appear.
+
+```shell
+. /etc/profile
+. /etc/env
+```
+
+[Add a completely new user without sudo capability](https://stal-ix.github.io/ETC#add-user).<br>
+
+Try logging in from tty1.
+
+What's next:
+
+Add uniqueness to the system, without it some packages refuse to install:
+
+```shell
+./ix mut system --seed="$(cat /dev/random | head -c 1000 | base64)"
+```
+
+[Set up Wi-Fi](WIFI.md)<br>
+[Some oddities](CAVEATS.md)<br>
+[System configuration](ETC.md)<br>
+[User login](LOGIN.md)
+
+<!-- {% endraw %} -->
+

--- a/INSTALL_SOURCE.md
+++ b/INSTALL_SOURCE.md
@@ -1,0 +1,149 @@
+# Installation from source
+<sup> The stal/IX on-disk installation guide from source code </sup>
+
+> Prerequisites:<br>
+> [IX.md](IX.md)<br>
+> [FS.md](FS.md)<br>
+
+<!-- {% raw %} -->
+
+Boot the machine from a bootable media, such as an Ubuntu/Fedora/NixOS live CD, and launch a terminal:
+
+```shell
+sudo sh
+```
+
+Install the tools:
+
+```shell
+test -f /usr/bin/parted || yum install parted || apt-get install parted
+# gcc >= 13 can't bootstrap IX right now, so we prefer Clang where possible
+test -f /usr/bin/g++ || yum install clang lld || yum install g++ || apt-get install g++
+test -f /usr/bin/git || yum install git || apt-get install git
+test -f /usr/bin/make || yum install make || apt-get install make
+```
+The exact commands for installing `parted`, `clang`/`g++`, `git`, and `make` will depend on the distribution that you use, but the above should work on Fedora, Red Hat Enterprise Linux, Debian, and their derivatives.
+
+For general instructions on partitioning a disk, see<br>
+[https://wiki.archlinux.org/title/installation_guide#Partition_the_disks](https://wiki.archlinux.org/title/Installation_guide#Partition_the_disks).<br>
+
+Prepare EXT4 (or any other file system) on /dev/xxx using `parted` (you can also use `fdisk` or `cfdisk`), `mkfs.ext4` (or the equivalent command for your file system), and mount it:
+
+```shell
+mkdir /mnt/ix
+mount /dev/xxx /mnt/ix
+```
+
+Prepare several symbolic links to form the future root filesystem:
+
+```shell
+cd /mnt/ix
+
+ln -s ix/realm/system/bin bin
+ln -s ix/realm/system/etc etc
+ln -s / usr
+
+mkdir -p home/root var sys proc dev tmp
+```
+
+Add a symbolic link to trick the **IX** package manager:
+
+```shell
+ln -s /mnt/ix/ix /ix
+```
+
+Add user "**ix**" who will own all packages on the system (note: UID 1000 is important):
+
+```shell
+useradd -ou 1000 ix
+```
+
+Prepare a managed directory owned by user **ix** in /ix, /ix/realm, etc.:
+
+```shell
+mkdir ix
+chown ix ix
+```
+
+Prepare the home directory of user **ix**, owned by **ix**:
+
+```shell
+mkdir home/ix
+chown ix home/ix
+```
+
+Change user to **ix** and run all commands as user **ix**:
+
+```shell
+su ix
+cd /mnt/ix
+```
+
+Download the **IX** package manager, which will be used later, as the ix user before rebooting and as the root user after rebooting:
+
+```shell
+# we don't want to change our CWD
+(cd home/ix; git clone https://github.com/stal-ix/ix.git)
+```
+
+Some oddities:
+
+```shell
+# like tmp dir, so realm symlink can be modified only by its creator/owner
+# it is important who create/own system realm, because only they can operate it
+# sudo chown {{username}} /ix/realm/system will help, iff one wants to transfer ownership 
+mkdir -m 01777 ix/realm
+```
+
+And run the **IX** package manager to populate the root filesystem with bootstrap tools:
+
+```shell
+cd home/ix/ix
+export IX_ROOT=/ix
+export IX_EXEC_KIND=local
+./ix mut system set/stalix --failsafe etc/zram/0
+./ix mut root set/install
+./ix mut boot set/boot/all
+```
+
+Now [prepare a bootable kernel for your hardware](KERNEL.md) and [install the GRUB bootloader](GRUB.md). Reboot into GRUB and select the menu entry corresponding to your kernel. After a successful boot, switch to tty5, the root prompt will appear.
+
+```shell
+. /etc/profile
+. /etc/env
+```
+
+We now have some useful utilities in the PATH from /ix/realm/root.
+
+```shell
+cd /home/ix/ix
+# very important step, rebuild system realm
+./ix mut system
+```
+
+After this, the shell will restart. In fact, after any change to the system realm, the init will restart the entire supervised process tree.
+
+```shell
+cd /home/ix/ix
+./ix mut $(./ix list)
+```
+
+Rebuild the world and [add a completely new user without sudo capability](https://stal-ix.github.io/ETC#add-user).<br>
+
+Try logging in from tty1.
+
+What's next: 
+
+Add uniqueness to the system, without it some packages refuse to install:
+
+```shell
+./ix mut system --seed="$(cat /dev/random | head -c 1000 | base64)"
+```
+
+[Set up Wi-Fi](WIFI.md)<br>
+[Some oddities](CAVEATS.md)<br>
+[System configuration](ETC.md)<br>
+[User login](LOGIN.md)
+
+<!-- {% endraw %} -->
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 [Blog](https://medium.com/@anton_samokhvalov)<br>
 [Design](STALIX.md)<br>
 [Support](https://t.me/stal_ix)<br>
-[Download](https://github.com/stal-ix/ix)<br>
+[Download](https://github.com/stal-ix/stalix/releases/latest)<br>
+[Source code repo](https://github.com/stal-ix/ix)<br>
 [Installation instructions](INSTALL.md)<br>
 [Packaging guide](PKG.md)<br>
 [Documentation style guide](GUIDE.md)<br>


### PR DESCRIPTION
I added a legacy BIOS section to `GRUB.md`. Also, GRUB expects its configuration file to be at `/boot/grub/grub.cfg`; if it's not there, then no menu entries will be shown at all and it will boot straight to the GRUB command line.

I added a rootfs-based installation guide at `INSTALL.md`. The source-based installation guide was moved to `INSTALL_source.md` and was labelled as "not recommended for beginners". In both of those guides, I replaced `/etc/session` with `/etc/profile` and `/etc/env`, and had users install the bootloader before (and NOT after) rebooting in case their installation media doesn't come with GRUB.

I removed the `--mingetty` flag, because mingetty is causing problems in my test installation. Later on, I will remove this flag from my scripts and remove mingetty altogether.

I updated the kernel guide at `KERNEL.md` to Linux version 6.15.3 and had users run `grep` in `pkgs/bin/kernel/6/15/ver.sh` instead of `pkgs/bin/kernel/kernels.json`. I also added `CC=cc LD=ld.ldd` to the `make menuconfig` command. The output of `lspci -k` can vary between distributions; if it says `Kernel driver in use`, then I tell the user to run `lspci -k | grep Kernel`. Finally, I added a section for [legacy BIOS oddities](https://github.com/stal-ix/ix/issues/754), and another that lists configuration options for hypervisors (just VMware for now).